### PR TITLE
rscala interface has updated

### DIFF
--- a/reachables/src/main/r/LCMSDataVisualisation/lcms_interface.R
+++ b/reachables/src/main/r/LCMSDataVisualisation/lcms_interface.R
@@ -28,7 +28,7 @@
 kFatJarLocation <- "reachables-assembly-0.1.jar"
 
 loginfo("Loading Scala interpreter from fat jar at %s.", kFatJarLocation)
-kScalaInterpreter=scalaInterpreter(kFatJarLocation)
+kScalaInterpreter=scala(kFatJarLocation)
 loginfo("Done loading Scala interpreter.")
 
 saveMoleculeStructure <- {

--- a/reachables/src/main/r/TextToRxnsUI/text_to_rxns.R
+++ b/reachables/src/main/r/TextToRxnsUI/text_to_rxns.R
@@ -25,7 +25,7 @@
 kFatJarLocation <- "reachables-assembly-0.1.jar"
 
 loginfo("Loading Scala interpreter from fat jar at %s.", kFatJarLocation)
-sc=scalaInterpreter(kFatJarLocation, heap.maximum="2096M")
+sc=scala(kFatJarLocation, heap.maximum="2096M")
 loginfo("Done loading Scala interpreter.")
 
 extractFromPlainText <- {

--- a/reachables/src/main/r/costModelUI/server.R
+++ b/reachables/src/main/r/costModelUI/server.R
@@ -110,7 +110,7 @@ plotGraph <- function(input, data, outcome) {
 
 shinyServer(function(input, output, session) {
   
-  sc=scalaInterpreter(kFatJarLocation)
+  sc=scala(kFatJarLocation)
   sc%~%kImportBingPackageCommand
   
   output$logo <- renderImage({


### PR DESCRIPTION
* rscala::scalaInterpreter is now rscala::scala
* https://cran.r-project.org/web/packages/rscala/rscala.pdf (rev Feb 8, 2017)